### PR TITLE
fix PTZ by passing user and password

### DIFF
--- a/FoscamFI8918W.pm
+++ b/FoscamFI8918W.pm
@@ -132,7 +132,7 @@ sub sendCmd
 	my $result = undef;
 	printMsg( $cmd, "Tx" );
  
-	my $req = HTTP::Request->new( GET=>"http://".$self->{Monitor}->{ControlAddress}."/$cmd" );
+	my $req = HTTP::Request->new( GET=>"http://".$self->{Monitor}->{ControlAddress}."/$cmd".$self->{Monitor}->{ControlDevice});
 	my $res = $self->{ua}->request($req);
  
 	if ( $res->is_success )


### PR DESCRIPTION
PTZ wasn't working on my system because the username and password wasn't
being passed to the camera, or at least, not in the way my system wants
it to go.

I changed "Control Device" to add an & at the start, eg:

	&user=<username>&pwd=<password>

With that change and my code mod, Control Device is appended to the URL used to control the camera

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>